### PR TITLE
Check for builtins as well as __builtin__

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,8 @@ CHANGES
 1.4 (unreleased)
 ================
 
-- Check for builtins (Python 3) everywhere that we check for __builtin__
-  (Python 2).
+- Check for ``builtins`` (Python 3) everywhere that we check for
+  ``__builtin__`` (Python 2).
 
 
 1.3.post1 (2019-03-14)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ CHANGES
 1.4 (unreleased)
 ================
 
-- Nothing changed yet.
+- Check for builtins (Python 3) everywhere that we check for __builtin__
+  (Python 2).
 
 
 1.3.post1 (2019-03-14)

--- a/src/martian/scan.py
+++ b/src/martian/scan.py
@@ -183,11 +183,11 @@ class BuiltinModuleInfo(object):
 
 def module_info_from_dotted_name(
         dotted_name, exclude_filter=None, ignore_nonsource=True):
-    if dotted_name == '__builtin__':
-        # in case of the use of individually grokking something during a
-        # test the dotted_name being passed in could be __builtin__
-        # in this case we return a special ModuleInfo that just
-        # implements enough interface to work
+    if dotted_name in {'__builtin__', 'builtins'}:
+        # In case of the use of individually grokking something during a
+        # test the dotted_name being passed in could be __builtin__ (Python
+        # 2) or builtins (Python 3).  In this case we return a special
+        # ModuleInfo that just implements enough interface to work.
         return BuiltinModuleInfo()
     module = resolve(dotted_name)
     return ModuleInfo(module.__file__, dotted_name, exclude_filter,

--- a/src/martian/scan.rst
+++ b/src/martian/scan.rst
@@ -256,3 +256,35 @@ However, if ``ignore_nonsource=False`` is passed to
    <ModuleInfo object for 'martian.tests.withpyconly.subpackage'>]
   >>> # rename back to normal name
   >>> os.rename(os.path.join(d, 'foo.py_aside'), os.path.join(d, 'foo.py'))
+
+The built-in module
+-------------------
+
+We might be asked to grok the built-in module (``__builtin__`` on Python 2,
+or ``builtins`` on Python 3).  For example, this can happen when grokking a
+component defined in a doctest using ``grokcore.component``.  The built-in
+module doesn't have a file, so we can't do things in the usual way; instead,
+we return a special object implementing just enough of the ``IModuleInfo``
+interface to work.
+
+  >>> import sys
+  >>> module_info = module_info_from_dotted_name(
+  ...     'builtins' if sys.version_info[0] >= 3 else '__builtin__')
+
+  >>> module_info.getModule()
+  <martian.scan.BuiltinDummyModule object at ...>
+
+  >>> module_info.isPackage()
+  False
+
+  >>> module_info.getSubModuleInfos()
+  []
+
+  >>> print(module_info.getSubModuleInfo('anything'))
+  None
+
+  >>> print(module_info.getResourcePath('anything'))
+  None
+
+  >>> module_info.getAnnotation('grok.foobar', 42)
+  42

--- a/src/martian/testing.py
+++ b/src/martian/testing.py
@@ -28,7 +28,7 @@ def fake_import(fake_module):
                 __module__ = obj.__module__
             except AttributeError:
                 pass
-        if __module__ is None or __module__ == '__builtin__':
+        if __module__ is None or __module__ in {'__builtin__', 'builtins'}:
             try:
                 obj.__module__ = module.__name__
             except AttributeError:


### PR DESCRIPTION
The __builtin__ module was renamed to builtins in Python 3, so check for
it in all the same places.