### PR TITLE
Fix test incompatibility with zope.interface 5.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ CHANGES
 1.5 (unreleased)
 ================
 
-- Nothing changed yet.
+- Fix test suite incompatibility with zope.interface >= 5.0.
 
 
 1.4 (2020-02-23)

--- a/src/martian/testing.py
+++ b/src/martian/testing.py
@@ -31,7 +31,7 @@ def fake_import(fake_module):
         if __module__ is None or __module__ in {'__builtin__', 'builtins'}:
             try:
                 obj.__module__ = module.__name__
-            except AttributeError:
+            except (AttributeError, TypeError):
                 pass
         setattr(module, name, obj)
 


### PR DESCRIPTION
Recent zope.interface versions made `Interface.__module__` a readonly attribute.  Without this fix, tests fail on Python 2.7 with

    Traceback (most recent call last):
      File "/usr/lib/python2.7/doctest.py", line 1315, in __run
        compileflags, 1) in test.globs
      File "<doctest directive.rst[105]>", line 1, in <module>
        class once_iface(FakeModule):
      File "/home/mg/src/zopefoundation/martian/src/martian/testing.py", line 65, in __init__
        fake_import(cls)
      File "/home/mg/src/zopefoundation/martian/src/martian/testing.py", line 33, in fake_import
        obj.__module__ = module.__name__
    TypeError: readonly attribute

(On Python 3 assignment to a readonly attribute raises an AttributeError instead, which was already caught.)