### PR TITLE
Drop Python 3.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,12 @@
 language: python
-dist: xenial
 python:
     - 2.7
-    - 3.4
     - 3.5
     - 3.6
     - 3.7
     - 3.8
-    - pypy2.7-6.0
-    - pypy3.5-6.0
+    - pypy
+    - pypy3
 install:
     - pip install -U pip setuptools
     - pip install -U zope.testrunner coverage coveralls

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ CHANGES
 
 - Fix test suite incompatibility with zope.interface >= 5.0.
 
+- Drop support for Python 3.4.
+
 
 1.4 (2020-02-23)
 ================

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
     py27,
-    py34,
     py35,
     py36,
     py37,
@@ -9,6 +8,7 @@ envlist =
     pypy,
     pypy3,
     coverage-report
+# try to keep this in sync with [tox:coverage-reports] 'depends =' please
 
 [testenv]
 usedevelop = true
@@ -22,7 +22,7 @@ deps =
     coverage
 
 [testenv:coverage-report]
-basepython = python3.6
+basepython = python3
 deps = coverage
 setenv =
   COVERAGE_FILE=.coverage
@@ -32,3 +32,12 @@ commands =
     coverage combine
     coverage html --ignore-errors
     coverage report --ignore-errors --fail-under=93
+parallel_show_output = true
+depends =
+    py27,
+    py35,
+    py36,
+    py37,
+    py38,
+    pypy,
+    pypy3,


### PR DESCRIPTION
Python 3.4 is EOL.

(This PR is based on top of #18 because otherwise tests would be broken.)